### PR TITLE
Add transparent asset nodes

### DIFF
--- a/py/api/gpt_image_2_alpha_synvow.py
+++ b/py/api/gpt_image_2_alpha_synvow.py
@@ -1,0 +1,446 @@
+# -*- coding: utf-8 -*-
+"""
+Alpha-aware SynVow GPT-Image-2 batch node.
+
+This file only adds new nodes. It reuses the existing GPT-Image-2 request,
+auth, submit, poll, and URL parsing helpers, and returns original image URLs
+so transparent PNGs can be saved directly with their alpha channel.
+"""
+
+import concurrent.futures
+import threading
+import time
+
+import comfy.utils
+import requests
+
+from . import synvow_auth
+from .gpt_image_2_synvow import (
+    _API_URL,
+    _MODEL_TYPE_OPTIONS,
+    _NEW_MODELS,
+    _POLL_URL,
+    _RATIO_TO_SIZE_1K,
+    _build_payload,
+    _extract_urls,
+    _is_changed,
+    _resolve_size_params,
+    _unpack,
+)
+
+
+CATEGORY = "💫SynVow_api/api/图像"
+TRANSPARENT_BACKGROUND_MODE = "固定透明(background=transparent)"
+SUBMIT_RETRY_ATTEMPTS = 3
+POLL_WORKER_LIMIT = 4
+_ALPHA_CANCEL_EVENT = threading.Event()
+
+
+class AlphaPollingCancelled(RuntimeError):
+    pass
+
+
+def request_alpha_cancel():
+    _ALPHA_CANCEL_EVENT.set()
+
+
+def _raise_if_alpha_cancelled():
+    if _ALPHA_CANCEL_EVENT.is_set():
+        raise AlphaPollingCancelled("已取消 GPT-Image-2 Alpha 轮询。")
+    try:
+        import comfy.model_management as mm
+        mm.throw_exception_if_processing_interrupted()
+    except AlphaPollingCancelled:
+        raise
+
+
+def _sleep_interruptible(seconds):
+    end_time = time.time() + seconds
+    while time.time() < end_time:
+        _raise_if_alpha_cancelled()
+        time.sleep(min(0.5, max(0, end_time - time.time())))
+    _raise_if_alpha_cancelled()
+
+
+def _poll_alpha_task(task_id, consumption_id, headers, poll_url, model):
+    poll_body = {"task_id": task_id, "model": model}
+    if consumption_id is not None:
+        poll_body["consumption_id"] = consumption_id
+    timeout_total = 1800
+    interval = 5
+    start_time = time.time()
+    consecutive_errors = 0
+    while True:
+        _sleep_interruptible(interval)
+        elapsed = int(time.time() - start_time)
+        if elapsed >= timeout_total:
+            print(f"[GPT-Image-2 Alpha] 超时: ...{task_id[-8:]} ({elapsed}s)")
+            return None
+        try:
+            _raise_if_alpha_cancelled()
+            poll_res = requests.post(poll_url, headers=headers, json=poll_body, timeout=30, verify=False)
+            _raise_if_alpha_cancelled()
+            poll_res.raise_for_status()
+            poll_json = poll_res.json()
+            consecutive_errors = 0
+            data_field = poll_json.get("data", poll_json) if isinstance(poll_json, dict) else poll_json
+            status = data_field.get("status", "") if isinstance(data_field, dict) else ""
+            print(f"[GPT-Image-2 Alpha] ...{task_id[-8:]} status={status} ({elapsed}s)")
+            if status in ("SUCCESS", "success", "succeeded", "completed", "done", "finished"):
+                return poll_json
+            if status in ("FAILURE", "failed", "error", "EXCEPTION"):
+                msg = data_field.get("fail_reason", "任务失败") if isinstance(data_field, dict) else "任务失败"
+                print(f"[GPT-Image-2 Alpha] 失败: ...{task_id[-8:]} {msg}")
+                return None
+        except AlphaPollingCancelled:
+            raise
+        except Exception as exc:
+            consecutive_errors += 1
+            print(f"[GPT-Image-2 Alpha] 轮询异常({consecutive_errors}/12): ...{task_id[-8:]} {exc}")
+            if consecutive_errors >= 12:
+                print(f"[GPT-Image-2 Alpha] 连续轮询异常过多，放弃: ...{task_id[-8:]}")
+                return None
+
+
+def _is_retryable_submit_error(exc):
+    text = str(exc or "").lower()
+    retry_markers = (
+        "excessive system load",
+        "too many requests",
+        "rate limit",
+        "timeout",
+        "temporarily",
+        "http 429",
+        "http 500",
+        "http 502",
+        "http 503",
+        "http 504",
+    )
+    return any(marker in text for marker in retry_markers)
+
+
+def _is_balance_or_auth_error(value):
+    text = str(value or "").lower()
+    markers = (
+        "账户余额不足",
+        "余额最少",
+        "insufficient balance",
+        "insufficient funds",
+        "quota",
+        "unauthorized",
+        "forbidden",
+        "invalid api key",
+        "api key",
+    )
+    return any(marker in text for marker in markers)
+
+
+def _response_error_text(response, limit=800):
+    try:
+        text = response.text or ""
+    except Exception:
+        text = ""
+    text = text.replace("\n", " ").replace("\r", " ").strip()
+    return text[:limit]
+
+
+def _post_generation_payload(api_url, headers, payload):
+    return requests.post(
+        api_url,
+        headers=headers,
+        json=payload,
+        params={"async": "true"},
+        timeout=120,
+        verify=False,
+    )
+
+
+def _official_image_payload_fallbacks(payload):
+    image_urls = payload.get("image_urls")
+    if payload.get("model") != "gpt-image-2-官方" or not image_urls:
+        return []
+
+    base = {key: value for key, value in payload.items() if key != "image_urls"}
+    return [
+        ("images", {**base, "images": image_urls}),
+        ("files", {**base, "files": [{"url": url, "type": "image"} for url in image_urls]}),
+    ]
+
+
+def _submit_alpha_task(payload, headers, api_url):
+    model = payload.get("model")
+    img_key = "image_urls" if "image_urls" in payload else "images"
+    img_count = len(payload.get(img_key, []))
+    print(f"[GPT-Image-2 Alpha] 提交: model={model} images={img_count}")
+    response = _post_generation_payload(api_url, headers, payload)
+    if response.status_code >= 400:
+        first_error = _response_error_text(response)
+        fallback_success = False
+        if not _is_balance_or_auth_error(first_error):
+            for field_name, fallback_payload in _official_image_payload_fallbacks(payload):
+                print(
+                    f"[GPT-Image-2 Alpha] 官方模型参考图提交失败，尝试兼容字段 {field_name}: "
+                    f"HTTP {response.status_code} {first_error}"
+                )
+                response = _post_generation_payload(api_url, headers, fallback_payload)
+                if response.status_code < 400:
+                    fallback_success = True
+                    print(f"[GPT-Image-2 Alpha] 官方模型参考图兼容字段 {field_name} 提交成功")
+                    break
+                print(
+                    f"[GPT-Image-2 Alpha] 官方模型参考图兼容字段 {field_name} 仍失败: "
+                    f"HTTP {response.status_code} {_response_error_text(response)}"
+                )
+        if not fallback_success:
+            raise RuntimeError(f"提交失败 HTTP {response.status_code}: {_response_error_text(response) or first_error}")
+
+    data = response.json() if isinstance(response.json(), dict) else {}
+    data_field = data.get("data")
+    data_item = (
+        data_field[0] if isinstance(data_field, list) and data_field else None
+    ) or (data_field if isinstance(data_field, dict) else {})
+    source_data = data_item.get("sourceData") or {}
+    source_inner = source_data.get("data")
+    source_item = source_inner[0] if isinstance(source_inner, list) and source_inner else {}
+    task_id = (
+        data.get("task_id")
+        or data_item.get("task_id")
+        or source_item.get("task_id")
+        or source_data.get("task_id")
+    )
+    consumption_id = data.get("consumption_id") or data_item.get("consumption_id")
+    if not task_id:
+        raise RuntimeError(f"提交失败，无 task_id: {str(data)[:200]}")
+    print(f"[GPT-Image-2 Alpha] task_id=...{task_id[-8:]}")
+    return task_id, consumption_id
+
+
+def _submit_alpha_task_with_retry(payload, headers, api_url):
+    last_exc = None
+    for attempt in range(1, SUBMIT_RETRY_ATTEMPTS + 1):
+        _raise_if_alpha_cancelled()
+        try:
+            return _submit_alpha_task(payload, headers, api_url)
+        except Exception as exc:
+            last_exc = exc
+            if attempt >= SUBMIT_RETRY_ATTEMPTS or not _is_retryable_submit_error(exc):
+                raise
+            wait_seconds = 4 * attempt
+            print(
+                f"[GPT-Image-2 Alpha] 提交遇到临时负载/限流，{wait_seconds}s 后重试 "
+                f"({attempt}/{SUBMIT_RETRY_ATTEMPTS}): {exc}"
+            )
+            _sleep_interruptible(wait_seconds)
+    raise last_exc
+
+
+def _normalize_model_type(model_type):
+    aliases = {"gpt-image-2-official": "gpt-image-2-官方"}
+    return aliases.get(str(model_type), model_type)
+
+
+def _send_alpha_refresh():
+    try:
+        synvow_auth.refresh_balance()
+    except Exception:
+        pass
+
+
+def _run_tasks_with_background(
+    tasks,
+    model,
+    size,
+    quality,
+    resolution,
+    is_img2img,
+    api_key,
+    headers,
+    seed=None,
+):
+    total = len(tasks)
+    pbar = comfy.utils.ProgressBar(total)
+    background = "transparent"
+    _raise_if_alpha_cancelled()
+
+    submitted = []
+    for index, (prompt, images) in enumerate(tasks):
+        _raise_if_alpha_cancelled()
+        payload = _build_payload(model, prompt, size, quality, resolution, is_img2img, images, api_key=api_key)
+        try:
+            seed_value = int(seed) if seed is not None else 0
+        except Exception:
+            seed_value = 0
+        if seed_value > 0:
+            payload["seed"] = seed_value
+        if background:
+            payload["background"] = background
+            if model not in _NEW_MODELS:
+                payload["transparentBackground"] = background == "transparent"
+        try:
+            task_id, consumption_id = _submit_alpha_task_with_retry(payload, headers, _API_URL)
+            submitted.append((task_id, consumption_id))
+            print(f"[GPT-Image-2 Alpha] [{index + 1}/{total}] 提交成功 task_id=...{task_id[-8:]}")
+        except Exception as exc:
+            print(f"[GPT-Image-2 Alpha] [{index + 1}/{total}] 提交失败: {exc}")
+            if _is_balance_or_auth_error(exc):
+                raise RuntimeError(
+                    f"GPT-Image-2 Alpha 提交失败：model={model}，mode={'参考图/拆图' if is_img2img else '文生图'}，"
+                    f"服务端返回：{exc}"
+                )
+            submitted.append(None)
+        if index < total - 1:
+            _sleep_interruptible(1)
+
+    def _poll_one(item):
+        _raise_if_alpha_cancelled()
+        if item is None:
+            pbar.update(1)
+            return None
+        task_id, consumption_id = item
+        result = _poll_alpha_task(task_id, consumption_id, headers, _POLL_URL, model)
+        pbar.update(1)
+        return result
+
+    worker_count = min(max(total, 1), POLL_WORKER_LIMIT)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:
+        poll_results = list(executor.map(_poll_one, submitted))
+
+    image_urls = []
+    for index, result in enumerate(poll_results):
+        if result is not None:
+            urls = _extract_urls(result)
+            if urls:
+                image_urls.extend(urls)
+            else:
+                print(f"[GPT-Image-2 Alpha] [{index + 1}/{total}] 任务完成但未解析到图片URL: {str(result)[:500]}")
+                image_urls.append(None)
+        else:
+            image_urls.append(None)
+    return image_urls
+
+
+class SynVowGptImage2Alpha_TBatch:
+    FUNCTION = "process_batch"
+    CATEGORY = CATEGORY
+    INPUT_IS_LIST = True
+    OUTPUT_IS_LIST = (False, False)
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model_type": (_MODEL_TYPE_OPTIONS, {"default": "gpt-image-2-1k-2605"}),
+                "quality": (["auto", "low", "medium", "high"], {"default": "auto"}),
+                "resolution": (["1K", "2K", "4K"], {"default": "1K"}),
+                "aspect_ratio": (list(_RATIO_TO_SIZE_1K.keys()), {"default": "1:1"}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647}),
+            },
+            "optional": {
+                "prompts_list": ("STRING", {"forceInput": True}),
+                "image1": ("IMAGE",),
+                "image2": ("IMAGE",),
+                "image3": ("IMAGE",),
+                "image4": ("IMAGE",),
+                "image5": ("IMAGE",),
+                "image6": ("IMAGE",),
+                "image7": ("IMAGE",),
+                "image8": ("IMAGE",),
+            },
+        }
+
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("image_urls", "status")
+    IS_CHANGED = staticmethod(_is_changed)
+
+    def process_batch(
+        self,
+        model_type=None,
+        quality=None,
+        resolution=None,
+        aspect_ratio=None,
+        seed=None,
+        prompts_list=None,
+        image1=None,
+        image2=None,
+        image3=None,
+        image4=None,
+        image5=None,
+        image6=None,
+        image7=None,
+        image8=None,
+    ):
+        _ALPHA_CANCEL_EVENT.clear()
+        model_type = _normalize_model_type(_unpack(model_type) or "gpt-image-2-1k-2605")
+        quality = _unpack(quality)
+        resolution = _unpack(resolution) or "1K"
+        aspect_ratio = _unpack(aspect_ratio)
+        seed = _unpack(seed)
+        image1 = _unpack(image1)
+        image2 = _unpack(image2)
+        image3 = _unpack(image3)
+        image4 = _unpack(image4)
+        image5 = _unpack(image5)
+        image6 = _unpack(image6)
+        image7 = _unpack(image7)
+        image8 = _unpack(image8)
+
+        api_key = synvow_auth.read_api_key()
+        headers = synvow_auth.make_api_headers(api_key)
+        model = model_type or "gpt-image-2-1k-2605"
+        eff_resolution, size = _resolve_size_params(model, aspect_ratio, resolution)
+
+        images = [item for item in [image1, image2, image3, image4, image5, image6, image7, image8] if item is not None]
+        is_img2img = len(images) > 0
+        prompts = prompts_list if isinstance(prompts_list, list) else ([prompts_list] if prompts_list else [""])
+        prompts = [prompt for prompt in prompts if prompt is not None] or [""]
+        tasks = [(prompt, images) for prompt in prompts]
+
+        print(f"[GPT-Image-2 Alpha TBatch] {len(tasks)} 条 prompt, model={model}, background=transparent")
+        image_urls = _run_tasks_with_background(
+            tasks,
+            model,
+            size,
+            quality,
+            eff_resolution,
+            is_img2img,
+            api_key,
+            headers,
+            seed=seed,
+        )
+        successful = sum(1 for url in image_urls if url)
+        if successful == 0:
+            raise RuntimeError(
+                f"GPT-Image-2 Alpha 生成失败：model={model}，mode={'参考图/拆图' if is_img2img else '文生图'}，"
+                f"total={len(tasks)}。请查看上方提交失败日志中的 HTTP 状态和服务端返回内容。"
+            )
+
+        status = (
+            f"已完成 {successful}/{len(tasks)} model={model} size={size} quality={quality}；"
+            f"输出URL {successful}/{len(image_urls)}；background={TRANSPARENT_BACKGROUND_MODE}；"
+            "请连接 image_urls 到 SynVow 透明PNG保存预览。"
+        )
+
+        print(f"[GPT-Image-2 Alpha TBatch] 完成: {successful}/{len(tasks)} urls={successful}/{len(image_urls)}")
+        _send_alpha_refresh()
+        return ("\n".join([url for url in image_urls if url]), status)
+
+
+try:
+    from aiohttp import web
+    import server
+
+    @server.PromptServer.instance.routes.post("/synvow/alpha/cancel")
+    async def _synvow_alpha_cancel(request):
+        request_alpha_cancel()
+        return web.json_response({"ok": True, "message": "GPT-Image-2 Alpha polling cancel requested"})
+except Exception as exc:
+    print(f"[GPT-Image-2 Alpha] 取消轮询接口注册失败: {exc}")
+
+
+NODE_CLASS_MAPPINGS = {
+    "SynVowGptImage2Alpha_TBatch": SynVowGptImage2Alpha_TBatch,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "SynVowGptImage2Alpha_TBatch": "SynVow GPT-Image-2 Alpha (T_batch)",
+}

--- a/py/api/transparent_asset_generator.py
+++ b/py/api/transparent_asset_generator.py
@@ -1,0 +1,818 @@
+# -*- coding: utf-8 -*-
+"""
+SynVow transparent asset prompt generator.
+
+This module only adds new ComfyUI nodes. It reuses the existing SynVow auth and
+LLM client, but leaves image generation to the existing GPT-Image-2 nodes.
+"""
+
+import hashlib
+import json
+import os
+import re
+from typing import Any, Dict, List, Tuple
+
+from .ymai_llm import chat_completion, default_model, fetch_models, image_to_data_urls
+
+
+CATEGORY = "💫SynVow_api/api/文本"
+NODE_VERSION = "2026-07-01-transparent-assets-prompts-only-v9"
+PROMPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "prompts"))
+PROMPT_CONFIG_PATH = os.path.join(PROMPTS_DIR, "transparent_asset_generator_prompts.json")
+CHARACTER_STICKER_CONSISTENCY_LOCK = (
+    "Treat this as one coherent sticker pack of the same original character. "
+    "Keep identical character identity, chibi head/bust proportions, face shape, eye rendering style, "
+    "hair color, hair length, hair parting, skin tone, line thickness, sticker outline/border, material, "
+    "lighting, camera angle and level of detail across all outputs. "
+    "Only the expression, small gesture or small prop may change. "
+    "Do not switch between 2D anime, 3D toy, semi-realistic portrait, flat vector, different eye styles "
+    "or different rendering materials."
+)
+
+
+def _load_prompt_config() -> Dict[str, Any]:
+    try:
+        with open(PROMPT_CONFIG_PATH, "r", encoding="utf-8") as file:
+            data = json.load(file)
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:
+        print(f"[TransparentAssetPrompts] 提示词配置读取失败，使用最小兜底配置: {exc}")
+        return {}
+
+
+PROMPT_CONFIG = _load_prompt_config()
+
+
+def _config_list(key: str, fallback: List[str]) -> List[str]:
+    value = PROMPT_CONFIG.get(key)
+    return value if isinstance(value, list) and value else fallback
+
+
+def _config_dict(key: str, fallback: Dict[str, Any] = None) -> Dict[str, Any]:
+    value = PROMPT_CONFIG.get(key)
+    return value if isinstance(value, dict) else (fallback or {})
+
+
+def _default_option(key: str, options: List[str], fallback: str) -> str:
+    defaults = _config_dict("defaults")
+    value = str(defaults.get(key, fallback))
+    return value if value in options else (options[0] if options else fallback)
+
+
+SCENE_PRESETS = _config_list("scene_presets", ["通用透明素材", "电商素材包"])
+PLANNER_MODES = _config_list("planner_modes", ["自动规划(LLM)", "规则预设(不调用LLM)"])
+ASSET_COUNTS = _config_list("asset_counts", ["1", "2", "4", "6", "8", "12"])
+STYLE_STRENGTHS = _config_list("style_strengths", ["保守", "标准", "丰富", "高表现"])
+COMPLEXITIES = _config_list("complexities", ["简洁", "适中", "丰富"])
+
+SCENE_HINTS = _config_dict("scene_hints")
+FALLBACK_ITEMS = _config_dict("fallback_items")
+TRANSPARENT_CONSTRAINTS = str(PROMPT_CONFIG.get(
+    "transparent_constraints",
+    "Transparent PNG asset, true transparent background, alpha channel, isolated subject, no scene background, no checkerboard, no transparency preview canvas, clean edge. Do not draw or simulate transparency.",
+))
+
+DEFAULT_SCENE = _default_option("scene_preset", SCENE_PRESETS, "电商素材包")
+DEFAULT_PLANNER_MODE = _default_option("planner_mode", PLANNER_MODES, "自动规划(LLM)")
+DEFAULT_ASSET_COUNT = _default_option("asset_count", ASSET_COUNTS, "6")
+DEFAULT_STYLE_STRENGTH = _default_option("style_strength", STYLE_STRENGTHS, "标准")
+DEFAULT_COMPLEXITY = _default_option("complexity", COMPLEXITIES, "适中")
+GENERIC_SCENE = "通用透明素材"
+LAYOUT_SPLIT_SCENE = "参考图分层拆图"
+LAYOUT_SPLIT_LAYER_NAMES = [
+    "文字/Logo层",
+    "主体/人物/产品层",
+    "背景层",
+    "装饰元素层",
+    "光影氛围层",
+    "其他可复用元素层",
+]
+
+
+def _unpack(value):
+    return value[0] if isinstance(value, list) else value
+
+
+def _safe_int(value, default=1):
+    try:
+        return int(str(value).strip())
+    except Exception:
+        return default
+
+
+def _stable_fingerprint(**kwargs):
+    payload = {key: str(value) for key, value in kwargs.items()}
+    payload["node_version"] = NODE_VERSION
+    payload["prompt_config_path"] = PROMPT_CONFIG_PATH
+    text = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+
+def _extract_json_object(text: str) -> Any:
+    raw = str(text or "").strip()
+    raw = re.sub(r"^```(?:json)?\s*", "", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"\s*```$", "", raw)
+    try:
+        return json.loads(raw)
+    except Exception:
+        pass
+
+    candidates = []
+    if "[" in raw and "]" in raw:
+        candidates.append(raw[raw.find("["): raw.rfind("]") + 1])
+    if "{" in raw and "}" in raw:
+        candidates.append(raw[raw.find("{"): raw.rfind("}") + 1])
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except Exception:
+            continue
+    raise ValueError(f"无法解析 LLM 返回的 JSON: {raw[:500]}")
+
+
+def _normalize_style_prompt(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    for key in ("style_prompt", "global_style_prompt", "style_lock", "shared_style"):
+        text = value.get(key)
+        if isinstance(text, str) and text.strip():
+            cleaned = re.sub(r"\s+", " ", text).strip()
+            return cleaned[:1600]
+    return ""
+
+
+def _layout_split_fallback_items(count: int, custom_prompt: str = "") -> List[Dict[str, str]]:
+    style_direction = _style_direction_from_custom_prompt(LAYOUT_SPLIT_SCENE, custom_prompt, count)
+    names = LAYOUT_SPLIT_LAYER_NAMES[:max(1, min(count, len(LAYOUT_SPLIT_LAYER_NAMES)))]
+    result = []
+    for name in names:
+        result.append({
+            "name": name,
+            "description": name,
+            "prompt": _single_custom_item_prompt(LAYOUT_SPLIT_SCENE, name, style_direction, []),
+        })
+    return result
+
+
+def _fallback_items(scene: str, count: int, custom_prompt: str = "") -> List[Dict[str, str]]:
+    if scene == GENERIC_SCENE:
+        base = custom_prompt.strip() or "transparent design asset"
+        result = []
+        for index in range(1, count + 1):
+            subject = base if count == 1 else f"{base}, variation {index}"
+            result.append({
+                "name": f"通用透明素材_{index:02d}",
+                "description": subject,
+                "prompt": _single_custom_item_prompt(scene, subject, "", []),
+            })
+        return result
+    if scene == LAYOUT_SPLIT_SCENE:
+        return _layout_split_fallback_items(count, custom_prompt)
+
+    custom_names = _extract_custom_item_names(scene, custom_prompt, count)
+    if custom_names:
+        item_names = [_scene_item_name(scene, name) for name in custom_names[:count]]
+        style_direction = _style_direction_from_custom_prompt(scene, custom_prompt, count)
+        result = []
+        for item_name in item_names:
+            other_names = [name for name in item_names if name != item_name]
+            result.append({
+                "name": item_name,
+                "description": item_name,
+                "prompt": _single_custom_item_prompt(scene, item_name, style_direction, other_names),
+            })
+        if len(result) >= count:
+            return result[:count]
+
+    names = FALLBACK_ITEMS.get(scene) or FALLBACK_ITEMS.get(DEFAULT_SCENE) or ["transparent design asset"]
+    style_direction = _style_direction_from_custom_prompt(scene, custom_prompt, count)
+    result = []
+    for index in range(count):
+        name = _scene_item_name(scene, str(names[index % len(names)]))
+        result.append({
+            "name": name,
+            "description": name,
+            "prompt": _single_custom_item_prompt(scene, name, style_direction, []),
+        })
+    return result
+
+
+def _extract_custom_item_names(scene: str, custom_prompt: str, count: int) -> List[str]:
+    text = str(custom_prompt or "").strip()
+    if not text or scene == GENERIC_SCENE:
+        return []
+
+    match = re.search(r"(?:包含|包括|含有|分别是|需要|拆出|提取|:|：)(.+)", text)
+    if match:
+        source = match.group(1)
+    else:
+        source = _implicit_item_list_source(text, count)
+        if not source:
+            return []
+
+    pieces = re.split(r"[、,，;；\n]+", source)
+    names = []
+    for piece in pieces:
+        token = re.split(r"(?:统一|同一|整体|风格|透明PNG|透明素材|适合|用于|不要)", piece.strip())[0].strip()
+        token = re.sub(r"^(?:和|以及|及|与)", "", token).strip()
+        token = re.sub(r"(?:图标|素材|贴纸|元素|道具)$", "", token).strip() or piece.strip()
+        if not token:
+            continue
+        if len(token) > 16:
+            continue
+        if any(word in token for word in ("统一", "风格", "透明", "素材包", "套装")):
+            continue
+        if token not in names:
+            names.append(token)
+        if len(names) >= count:
+            break
+    return names
+
+
+def _implicit_item_list_source(text: str, count: int) -> str:
+    parts = re.split(r"[，,：:]", str(text or ""), maxsplit=1)
+    if len(parts) < 2:
+        return ""
+    suffix = parts[1].strip()
+    pieces = [piece.strip() for piece in re.split(r"[、,，;；\n]+", suffix) if piece.strip()]
+    if len(pieces) < min(max(count, 2), 2):
+        return ""
+    meaningful = [
+        piece for piece in pieces
+        if not any(word in piece for word in ("统一", "风格", "透明PNG", "透明素材", "素材包", "套装"))
+    ]
+    return suffix if len(meaningful) >= 2 else ""
+
+
+def _looks_like_item_token(scene: str, value: str) -> bool:
+    token = str(value or "").strip()
+    if not token or len(token) > 18:
+        return False
+    style_markers = (
+        "统一", "同一", "整体", "风格", "透明PNG", "透明素材", "素材包", "套装",
+    )
+    if any(word in token for word in style_markers):
+        return False
+    scene_keywords = {
+        "电商素材包": ("标签", "底板", "箭头", "粒子", "光环", "水滴", "胶囊", "元素", "道具", "装饰", "高光", "碎片"),
+        "参考图分层拆图": ("文字", "Logo", "主体", "人物", "产品", "背景", "装饰", "元素", "光影", "氛围", "层"),
+        "UI图标套装": ("图标", "生成", "编辑", "上传", "下载", "收藏", "设置", "搜索", "首页", "订单", "支付", "用户", "数据"),
+        "人物/IP贴纸": ("贴纸", "表情", "动作", "挥手", "点赞", "比心", "疑问", "开心", "角色"),
+        "周边贴纸素材": ("贴纸", "徽章", "冰箱贴", "手账", "封口贴", "立牌", "图案", "装饰"),
+        "游戏道具素材": ("金币", "宝箱", "药水", "水晶", "武器", "护盾", "技能", "卡牌", "挂件", "奖励", "道具"),
+        "节日活动素材": ("礼盒", "彩带", "优惠券", "倒计时", "角标", "金币", "烟花", "爆炸贴", "标签", "徽章"),
+    }
+    keywords = scene_keywords.get(scene, ())
+    if any(word in token for word in keywords):
+        return True
+    style_descriptors = (
+        "电商", "主图", "科技", "高端", "可爱", "蓝紫", "蓝色", "紫色", "红色", "金色",
+        "清透", "轻拟物", "3D", "扁平", "手绘", "写实", "赛博", "奇幻", "春节", "双11",
+    )
+    if any(word in token for word in style_descriptors):
+        return False
+    return len(token) <= 8
+
+
+def _scene_item_name(scene: str, name: str) -> str:
+    clean = str(name or "").strip()
+    if scene == LAYOUT_SPLIT_SCENE:
+        return clean if clean.endswith("层") else f"{clean}层"
+    if scene == "UI图标套装":
+        return clean if clean.endswith("图标") else f"{clean}图标"
+    if scene == "游戏道具素材":
+        return clean if clean.endswith(("图标", "道具", "素材")) else f"{clean}道具图标"
+    if scene in ("人物/IP贴纸", "周边贴纸素材"):
+        return clean if clean.endswith("贴纸") else f"{clean}贴纸"
+    if scene == "节日活动素材":
+        return clean if clean.endswith(("元素", "素材", "贴纸", "标签", "底板")) else f"{clean}元素"
+    return clean if clean.endswith(("素材", "元素", "标签", "底板", "图标")) else f"{clean}素材"
+
+
+_UI_ICON_ENGLISH_HINTS = {
+    "生成": "AI generation sparkle or magic-wand symbol",
+    "编辑": "pencil edit symbol",
+    "上传": "upward arrow upload symbol",
+    "下载": "downward arrow download symbol",
+    "收藏": "favorite heart or star symbol",
+    "设置": "settings gear symbol",
+    "搜索": "magnifying glass search symbol",
+    "首页": "home symbol",
+    "消息": "message bubble symbol",
+    "订单": "order document symbol",
+    "支付": "payment card symbol",
+    "数据": "analytics chart symbol",
+    "商品": "product box symbol",
+    "用户": "user profile symbol",
+    "客服": "customer service headset symbol",
+    "物流": "delivery truck symbol",
+}
+
+
+_UI_ICON_SYMBOL_LOCKS = {
+    "上传": (
+        "Use one upward arrow rising from a simple tray or cloud base. "
+        "Do not use a downward arrow or download tray."
+    ),
+    "下载": (
+        "Use one downward arrow entering a simple tray or inbox. "
+        "Do not use an upward arrow, cloud upload symbol, or extra mini icons."
+    ),
+}
+
+
+def _style_direction_from_custom_prompt(scene: str, custom_prompt: str, count: int = 0) -> str:
+    text = str(custom_prompt or "").strip()
+    if not text:
+        return ""
+    if scene in (GENERIC_SCENE, LAYOUT_SPLIT_SCENE):
+        return text
+
+    text = re.sub(
+        r"(?:包含|包括|含有|分别是|需要|拆出|提取)[^。；;]*?"
+        r"(?=(?:，|,)?(?:统一|同一|整体|保持|风格|蓝|紫|红|金|科技|可爱|高端|简洁|轻拟物|3D|扁平|手绘|写实)|[。；;]|$)",
+        "",
+        text,
+    )
+    implicit_source = _implicit_item_list_source(text, count or 2)
+    if implicit_source:
+        style_prefix_parts = re.split(r"[，,：:]", text, maxsplit=1)
+        style_prefix = style_prefix_parts[0].strip() if len(style_prefix_parts) > 1 else ""
+        segments = [seg.strip() for seg in re.split(r"[、,，;；\n]+", text) if seg.strip()]
+        kept = []
+        for seg in segments:
+            if style_prefix and seg == style_prefix:
+                kept.append(seg)
+                continue
+            if not _looks_like_item_token(scene, seg):
+                kept.append(seg)
+        if not kept and style_prefix:
+            kept.append(style_prefix)
+        text = "，".join(kept)
+    text = re.sub(r"\s+", " ", text)
+    text = re.sub(r"[，,]\s*[，,]+", "，", text)
+    text = text.strip("，,。；; ")
+    return text or str(custom_prompt or "").strip()
+
+
+def _ui_icon_subject(item_name: str) -> str:
+    label = str(item_name or "").strip()
+    base = label[:-2] if label.endswith("图标") else label
+    hint = _UI_ICON_ENGLISH_HINTS.get(base)
+    return f"{label} ({hint})" if hint else label
+
+
+def _ui_icon_symbol_lock(item_name: str) -> str:
+    label = str(item_name or "").strip()
+    base = label[:-2] if label.endswith("图标") else label
+    return _UI_ICON_SYMBOL_LOCKS.get(base, "")
+
+
+def _layout_split_item_prompt(item_name: str, style_direction: str) -> str:
+    style_text = f" User split instruction: {style_direction}." if style_direction else ""
+    common = (
+        "Use the connected reference image as the only source of truth. "
+        "Do not invent new props, mascots, icons, food, stickers, text, or unrelated design assets. "
+        "Preserve the reference image's visual identity, placement logic, color relationship, and commercial poster style."
+    )
+    if "文字" in item_name or "Logo" in item_name or "logo" in item_name.lower():
+        return (
+            "Recreate only the visible text, typography, logo marks, brand marks, numbers, and small written labels from the reference image "
+            "as one transparent overlay layer. Preserve their approximate shapes, colors, positions, scale relationships, and hierarchy. "
+            "Do not include the person, product, background, decorative props, shadows, or scene surfaces. Visible text is allowed for this layer. "
+            f"{common}{style_text}"
+        )
+    if any(word in item_name for word in ("主体", "人物", "产品", "主角")):
+        return (
+            "Recreate only the main foreground subject layer from the reference image: the primary person/IP/character and the main held or displayed product if present. "
+            "Preserve pose, crop, silhouette, clothing/product shape, and the relationship between person and product. "
+            "Do not include text/logo, background walls/floor, decorative stickers, floating props, or unrelated objects. "
+            f"{common}{style_text}"
+        )
+    if "背景" in item_name:
+        return (
+            "Recreate only the background layer from the reference image as a clean full-frame background plate. "
+            "Preserve the main background colors, gradients, wall/floor planes, lighting direction, and broad composition. "
+            "Remove the person, product, text/logo, foreground stickers, mascots, decorative props, and floating elements. "
+            "The background layer may be opaque and rectangular; do not add new objects. "
+            f"{common}{style_text}"
+        )
+    if any(word in item_name for word in ("装饰", "元素", "光影", "氛围", "其他")):
+        return (
+            "Recreate only the visible decorative foreground elements from the reference image as one transparent overlay layer. "
+            "This can include existing stickers, mascots, props, sparkles, drops, ribbons, light accents, badges, or small decoration elements that are actually visible in the reference. "
+            "Do not include text/logo, the main person, main product, or background plate. Do not add new decorations that are not in the reference. "
+            f"{common}{style_text}"
+        )
+    return (
+        f"Recreate only the {item_name} from the reference image as a separate design layer. "
+        f"{common}{style_text}"
+    )
+
+
+def _single_custom_item_prompt(scene: str, item_name: str, style_direction: str, other_names: List[str]) -> str:
+    style_text = f" Style direction: {style_direction}." if style_direction else ""
+    one_asset_rule = (
+        "This prompt is for the current asset only. "
+        "The output canvas must contain exactly one object only."
+    )
+    if scene == LAYOUT_SPLIT_SCENE:
+        return _layout_split_item_prompt(item_name, style_direction)
+    if scene == "UI图标套装":
+        symbol_lock = _ui_icon_symbol_lock(item_name)
+        symbol_text = f" {symbol_lock}" if symbol_lock else ""
+        return (
+            f"Generate exactly one standalone UI icon: {_ui_icon_subject(item_name)}. "
+            f"{one_asset_rule} Only this single symbol, no icon sheet, no icon grid, no small icon cluster, no extra icons."
+            f"{symbol_text}{style_text}"
+        )
+    if scene == "电商素材包":
+        return f"Generate exactly one standalone ecommerce overlay asset: {item_name}. {one_asset_rule} No ecommerce poster, no product main image, no layout, no asset sheet, no extra props.{style_text}"
+    if scene == "游戏道具素材":
+        return f"Generate exactly one standalone game asset icon: {item_name}. {one_asset_rule} Only this single prop or item, no inventory grid, no item sheet, no full game scene.{style_text}"
+    if scene == "人物/IP贴纸":
+        return (
+            f"Generate exactly one simple original cartoon mascot/emote sticker asset: {item_name}. "
+            f"{one_asset_rule} Use one non-real-person mascot head, bust, or simple rounded character with one clear expression or gesture. "
+            "If a reference image is provided, convert it into one consistent original chibi sticker character; "
+            "preserve only general hair, face and color cues, not a photoreal portrait. "
+            f"{CHARACTER_STICKER_CONSISTENCY_LOCK} "
+            "Avoid realistic human likeness, celebrity likeness, photoreal face, complex full-body anatomy, detailed hands, multiple characters, "
+            "sticker sheet, multiple poses in one image, or mockup scene."
+            f"{style_text}"
+        )
+    if scene == "周边贴纸素材":
+        return f"Generate exactly one standalone merchandise sticker asset: {item_name}. {one_asset_rule} Only this single sticker or merchandise artwork, no sticker sheet, no product mockup scene.{style_text}"
+    if scene == "节日活动素材":
+        return f"Generate exactly one standalone holiday campaign asset: {item_name}. {one_asset_rule} Only this single reusable element, no element sheet, no complete poster, no layout, no other campaign elements.{style_text}"
+    return f"Generate exactly one standalone transparent asset: {item_name}. {one_asset_rule} Only this single reusable element, no asset sheet, no complete design layout.{style_text}"
+
+
+_MULTI_ASSET_PROMPT_HINTS = (
+    "asset sheet", "icon sheet", "sticker sheet", "item sheet", "contact sheet",
+    "icon grid", "item grid", "grid of", "nine-grid", "9-grid", "3x3",
+    "collage", "collection", "multiple", "many", "several", "various",
+    "set of icons", "icon set", "sticker set", "asset pack", "all icons", "all items",
+    "full poster", "poster layout", "main image layout", "ui screen", "full interface",
+    "九宫格", "宫格", "网格", "拼图", "合集", "集合", "整套", "全套", "一整套",
+    "图标套装", "图标组", "图标表", "贴纸套装", "贴纸表", "素材包", "素材表",
+    "道具栏", "多个", "多张", "多种", "一组", "成套", "包含", "包括",
+)
+
+
+def _prompt_mentions_multi_asset(prompt: str) -> bool:
+    text = str(prompt or "")
+    lower = text.lower()
+    return any(hint in lower for hint in _MULTI_ASSET_PROMPT_HINTS)
+
+
+def _enforce_single_asset_prompt(scene: str, name: str, prompt: str, custom_prompt: str, count: int) -> str:
+    style_direction = _style_direction_from_custom_prompt(scene, custom_prompt, count)
+    single_prompt = _single_custom_item_prompt(scene, name, style_direction, [])
+    if scene == LAYOUT_SPLIT_SCENE:
+        return single_prompt
+    raw_prompt = re.sub(r"\s+", " ", str(prompt or "")).strip()
+    if not raw_prompt or _prompt_mentions_multi_asset(raw_prompt):
+        return single_prompt
+    return (
+        f"{single_prompt} Preserve only relevant single-object visual details from planner: "
+        f"{raw_prompt}. Ignore any wording that implies a pack, sheet, grid, multiple objects, "
+        f"complete layout, poster, UI screen, or scene."
+    )
+
+
+def _normalize_items(value: Any, count: int, scene: str, custom_prompt: str = "") -> List[Dict[str, str]]:
+    if scene == LAYOUT_SPLIT_SCENE:
+        return _layout_split_fallback_items(count, custom_prompt)
+
+    if isinstance(value, dict):
+        items = value.get("items", [])
+    elif isinstance(value, list):
+        items = value
+    else:
+        items = []
+
+    normalized = []
+    for index, item in enumerate(items[:count], start=1):
+        if isinstance(item, str):
+            name = item.strip()
+            description = item.strip()
+            prompt = item.strip()
+        elif isinstance(item, dict):
+            name = str(item.get("name") or item.get("title") or f"asset_{index:02d}").strip()
+            description = str(item.get("description") or item.get("usage") or name).strip()
+            prompt = str(item.get("prompt") or item.get("image_prompt") or description or name).strip()
+        else:
+            continue
+        if prompt:
+            normalized.append({
+                "name": name,
+                "description": description,
+                "prompt": _enforce_single_asset_prompt(scene, name, prompt, custom_prompt, count),
+            })
+
+    if len(normalized) < count:
+        fallback = _fallback_items(scene, count, custom_prompt)
+        normalized.extend(fallback[len(normalized):count])
+    return normalized[:count]
+
+
+def _planner_system_prompt() -> str:
+    return str(PROMPT_CONFIG.get(
+        "planner_system_prompt",
+        "You are a transparent PNG asset planner. Return strict JSON only with items.",
+    ))
+
+
+def _plan_with_llm(
+    scene: str,
+    count: int,
+    custom_prompt: str,
+    style_strength: str,
+    complexity: str,
+    llm_model: str,
+    product_image=None,
+    style_image=None,
+) -> Tuple[List[Dict[str, str]], str, str]:
+    image_urls: List[str] = []
+    if product_image is not None:
+        image_urls.extend(image_to_data_urls(product_image))
+    if style_image is not None:
+        image_urls.extend(image_to_data_urls(style_image))
+
+    user_payload = {
+        "scene_preset": scene,
+        "asset_count": count,
+        "scene_strategy": SCENE_HINTS.get(scene, ""),
+        "user_direction": custom_prompt or "",
+        "style_strength": style_strength,
+        "visual_complexity": complexity,
+        "reference_images": {
+            "product_or_ip_reference": product_image is not None,
+            "style_reference": style_image is not None,
+        },
+        "requirements": _config_list("planner_requirements", [
+            "Plan exactly asset_count items.",
+            "Each item must be reusable as a transparent PNG component.",
+            "The whole pack must share one consistent visual style.",
+            "Do not plan full posters, full ecommerce main images, or full UI screens.",
+        ]),
+    }
+    content = chat_completion(
+        llm_model,
+        _planner_system_prompt(),
+        json.dumps(user_payload, ensure_ascii=False),
+        image_urls=image_urls,
+        temperature=0.35,
+        max_tokens=3500,
+        timeout=240,
+    )
+    parsed = _extract_json_object(content)
+    return _normalize_items(parsed, count, scene, custom_prompt), content, _normalize_style_prompt(parsed)
+
+
+def _style_lock(scene: str, style_strength: str, complexity: str, custom_prompt: str, count: int = 0) -> str:
+    strength_map = _config_dict("style_strength_map")
+    complexity_map = _config_dict("complexity_map")
+    style_direction = _style_direction_from_custom_prompt(scene, custom_prompt, count)
+    return (
+        f"Shared visual style: {SCENE_HINTS.get(scene, '')} "
+        f"Style strength: {strength_map.get(style_strength, style_strength)}. "
+        f"Complexity: {complexity_map.get(complexity, complexity)}. "
+        f"User direction: {style_direction or 'follow the scene preset'}."
+    )
+
+
+def _compose_style_lock(base_style: str, planner_style_prompt: str) -> str:
+    base_style = str(base_style or "").strip()
+    planner_style_prompt = str(planner_style_prompt or "").strip()
+    if not planner_style_prompt:
+        return base_style
+    return (
+        f"{base_style}\n"
+        f"Global style prompt generated by planner, apply identically to every output: {planner_style_prompt}\n"
+        "Do not reinterpret or vary this global style prompt between assets; only change the requested asset subject, expression, gesture or function."
+    )
+
+
+def _scene_generation_rules(scene: str) -> str:
+    rules = _config_dict("scene_generation_rules")
+    return str(rules.get(scene) or rules.get(GENERIC_SCENE) or "Generate one transparent reusable asset.")
+
+
+def _transparent_constraints_for_item(scene: str, item_name: str) -> str:
+    if scene != LAYOUT_SPLIT_SCENE:
+        return TRANSPARENT_CONSTRAINTS
+    name = str(item_name or "")
+    if "背景" in name:
+        return (
+            "Layer constraints: output the background layer only. A full-frame opaque or semi-opaque rectangular background plate is allowed. "
+            "Do not include text, logo, person, product, foreground decoration, stickers, mascots, or checkerboard/fake transparency."
+        )
+    if "文字" in name or "Logo" in name or "logo" in name.lower():
+        return (
+            "Layer constraints: output a transparent PNG overlay with real alpha outside the text/logo marks. "
+            "Visible typography, numbers, brand marks, and logo shapes from the reference are allowed. "
+            "Do not include person, product, background, foreground props, decorations, checkerboard, or fake transparency."
+        )
+    return (
+        "Layer constraints: output a transparent PNG overlay with real alpha outside this foreground layer. "
+        "Keep only the requested layer content from the reference image. Do not include text/logo, background plate, unrelated objects, checkerboard, or fake transparency."
+    )
+
+
+def _build_generation_prompt(
+    scene: str,
+    item: Dict[str, str],
+    style_lock: str,
+    index: int,
+    count: int,
+) -> str:
+    template_key = "layout_split_generation_prompt_template" if scene == LAYOUT_SPLIT_SCENE else "generation_prompt_template"
+    template = PROMPT_CONFIG.get(template_key)
+    if isinstance(template, str):
+        lines = template.splitlines()
+    elif isinstance(template, list):
+        lines = [str(line) for line in template]
+    else:
+        lines = [
+            "Asset {index} of {count}: {item_prompt}",
+            "Asset name: {item_name}",
+            "{style_lock}",
+            "{scene_rule}",
+            "{transparent_constraints}",
+            "Output only the isolated subject on real alpha transparency. Do not visualize transparency as a checkerboard, gray-white grid, preview canvas, background, frame, canvas texture, floor shadow, watermark, signature, or extra objects.",
+        ]
+
+    context = {
+        "index": index,
+        "count": count,
+        "item_prompt": item.get("prompt", "").strip(),
+        "item_name": item.get("name", "").strip(),
+        "style_lock": style_lock,
+        "scene_rule": _scene_generation_rules(scene),
+        "transparent_constraints": _transparent_constraints_for_item(scene, item.get("name", "")),
+    }
+    rendered = []
+    for line in lines:
+        try:
+            value = line.format(**context)
+        except Exception:
+            value = line
+        value = str(value).strip()
+        if value:
+            rendered.append(value)
+    return "\n".join(rendered)
+
+
+def _plain_prompt_text(items: List[Dict[str, str]], prompts: List[str]) -> str:
+    blocks = []
+    for index, (item, prompt) in enumerate(zip(items, prompts), start=1):
+        blocks.append(
+            f"{index:02d}. {item.get('name', '')}\n"
+            f"{item.get('description', '')}\n"
+            f"{prompt}"
+        )
+    return "\n\n---\n\n".join(blocks)
+
+
+class SynVowTransparentAssetPromptGenerator:
+    FUNCTION = "generate"
+    CATEGORY = CATEGORY
+    INPUT_IS_LIST = True
+    OUTPUT_IS_LIST = (True, False, False, False)
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        llm_models = fetch_models()
+        return {
+            "required": {
+                "scene_preset": (SCENE_PRESETS, {"default": DEFAULT_SCENE}),
+                "planner_mode": (PLANNER_MODES, {"default": DEFAULT_PLANNER_MODE}),
+                "asset_count": (ASSET_COUNTS, {"default": DEFAULT_ASSET_COUNT}),
+                "custom_prompt": ("STRING", {"multiline": True, "default": ""}),
+                "llm_model": (llm_models, {"default": default_model(llm_models)}),
+                "style_strength": (STYLE_STRENGTHS, {"default": DEFAULT_STYLE_STRENGTH}),
+                "complexity": (COMPLEXITIES, {"default": DEFAULT_COMPLEXITY}),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 2147483647}),
+            },
+            "optional": {
+                "product_or_reference_image": ("IMAGE",),
+                "style_reference_image": ("IMAGE",),
+            },
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "STRING", "STRING")
+    RETURN_NAMES = (
+        "prompts_list",
+        "asset_plan_json",
+        "prompts_text",
+        "status",
+    )
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return _stable_fingerprint(**kwargs)
+
+    def generate(
+        self,
+        scene_preset,
+        planner_mode,
+        asset_count,
+        custom_prompt,
+        llm_model,
+        style_strength,
+        complexity,
+        seed,
+        product_or_reference_image=None,
+        style_reference_image=None,
+    ):
+        scene = _unpack(scene_preset) or DEFAULT_SCENE
+        planner_mode = _unpack(planner_mode) or DEFAULT_PLANNER_MODE
+        count = _safe_int(_unpack(asset_count), _safe_int(DEFAULT_ASSET_COUNT, 6))
+        custom_prompt = str(_unpack(custom_prompt) or "").strip()
+        llm_model = _unpack(llm_model) or default_model(fetch_models())
+        style_strength = _unpack(style_strength) or DEFAULT_STYLE_STRENGTH
+        complexity = _unpack(complexity) or DEFAULT_COMPLEXITY
+        product_or_reference_image = _unpack(product_or_reference_image)
+        style_reference_image = _unpack(style_reference_image)
+
+        if scene == GENERIC_SCENE and not custom_prompt:
+            raise RuntimeError("通用透明素材模式需要填写 custom_prompt。")
+
+        llm_debug = ""
+        planner_style_prompt = ""
+        if scene == LAYOUT_SPLIT_SCENE:
+            items = _fallback_items(scene, count, custom_prompt)
+            plan_source = "layer_preset"
+        elif scene == GENERIC_SCENE or planner_mode == "规则预设(不调用LLM)":
+            items = _fallback_items(scene, count, custom_prompt)
+            plan_source = "rule"
+        else:
+            try:
+                items, llm_debug, planner_style_prompt = _plan_with_llm(
+                    scene,
+                    count,
+                    custom_prompt,
+                    style_strength,
+                    complexity,
+                    llm_model,
+                    product_or_reference_image,
+                    style_reference_image,
+                )
+                plan_source = f"llm:{llm_model}"
+            except Exception as exc:
+                print(f"[TransparentAssetPrompts] LLM 规划失败，使用规则预设: {exc}")
+                items = _fallback_items(scene, count, custom_prompt)
+                plan_source = f"rule_fallback:{exc}"
+
+        base_style = _style_lock(scene, style_strength, complexity, custom_prompt, count)
+        style = _compose_style_lock(base_style, planner_style_prompt)
+        prompts = [
+            _build_generation_prompt(scene, item, style, index, len(items))
+            for index, item in enumerate(items, start=1)
+        ]
+
+        plan = {
+            "scene_preset": scene,
+            "planner_mode": planner_mode,
+            "plan_source": plan_source,
+            "prompt_config_path": PROMPT_CONFIG_PATH,
+            "asset_count": len(items),
+            "style_strength": style_strength,
+            "complexity": complexity,
+            "style_prompt_source": "llm" if planner_style_prompt else "rule",
+            "style_prompt": planner_style_prompt or base_style,
+            "items": [
+                {
+                    "index": index,
+                    "name": item.get("name", ""),
+                    "description": item.get("description", ""),
+                    "planner_prompt": item.get("prompt", ""),
+                    "generation_prompt": prompts[index - 1],
+                }
+                for index, item in enumerate(items, start=1)
+            ],
+        }
+        if llm_debug:
+            plan["llm_raw_response"] = llm_debug
+
+        status = (
+            f"透明素材提示词生成完成：scene={scene}，规划={plan_source}，"
+            f"输出 {len(prompts)} 条提示词。可直接连接到 SynVow GPT-Image-2 Alpha (T_batch) 的 prompts_list。"
+        )
+        return (
+            prompts,
+            json.dumps(plan, ensure_ascii=False, indent=2),
+            _plain_prompt_text(items, prompts),
+            status,
+        )
+
+
+NODE_CLASS_MAPPINGS = {
+    "SynVowTransparentAssetPromptGenerator": SynVowTransparentAssetPromptGenerator,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "SynVowTransparentAssetPromptGenerator": "SynVow 透明素材提示词生成器",
+}

--- a/py/image/transparent_png_save_preview.py
+++ b/py/image/transparent_png_save_preview.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+"""Save transparent PNG images directly from original image URLs."""
+
+import json
+import io
+import os
+import random
+import re
+from collections import deque
+from typing import List, Optional
+
+import numpy as np
+import requests
+import torch
+import urllib3
+from PIL import Image
+from PIL.PngImagePlugin import PngInfo
+
+import folder_paths
+from comfy.cli_args import args
+
+
+CATEGORY = "💫SynVow_api/Image"
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def _unpack(value):
+    return value[0] if isinstance(value, list) and len(value) == 1 else value
+
+
+def _safe_relative_path(value, default="") -> str:
+    text = str(_unpack(value) or default).strip().replace("\\", "/")
+    text = re.sub(r"^[A-Za-z]:", "", text).strip("/")
+    parts = []
+    for part in text.split("/"):
+        part = part.strip()
+        if not part or part in {".", ".."}:
+            continue
+        parts.append(re.sub(r'[<>:"|?*\x00-\x1f]', "_", part))
+    return "/".join(parts)
+
+
+def _safe_filename_prefix(value, default="transparent") -> str:
+    text = _safe_relative_path(value, default=default)
+    text = text.replace("/", "_").strip("_")
+    return text or default
+
+
+def _raw_path(value, default="") -> str:
+    return str(_unpack(value) or default).strip().strip('"')
+
+
+def _is_absolute_save_path(value: str) -> bool:
+    text = str(value or "").strip()
+    return bool(re.match(r"^[A-Za-z]:[\\/]", text)) or os.path.isabs(text)
+
+
+def _next_counter(folder: str, filename_prefix: str) -> int:
+    counter = 1
+    while True:
+        candidate = os.path.join(folder, f"{filename_prefix}_{counter:05}_alpha.png")
+        if not os.path.exists(candidate):
+            return counter
+        counter += 1
+
+
+def _next_available_png_path(folder: str, filename_prefix: str, start_counter: int) -> tuple:
+    counter = max(1, int(start_counter or 1))
+    while True:
+        filename = f"{filename_prefix}_{counter:05}_alpha.png"
+        path = os.path.join(folder, filename)
+        if not os.path.exists(path):
+            return path, filename, counter
+        counter += 1
+
+
+def _collect_urls(value) -> List[str]:
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    urls = []
+    for item in items:
+        if item is None:
+            continue
+        text = str(item)
+        for url in re.findall(r"https?://[^\s\"'<>]+", text):
+            cleaned = url.rstrip("),，。；;")
+            if cleaned and cleaned not in urls:
+                urls.append(cleaned)
+    return urls
+
+
+def _download_rgba_from_url(url: str) -> Optional[Image.Image]:
+    short = f"...{url[-24:]}" if len(url) > 24 else url
+    for attempt in range(3):
+        try:
+            response = requests.get(url, timeout=120, verify=False)
+            response.raise_for_status()
+            rgba = Image.open(io.BytesIO(response.content)).convert("RGBA")
+            print(f"[SynVowTransparentSave] URL RGBA 下载成功 ({attempt + 1}/3): {short} {rgba.width}x{rgba.height}")
+            return rgba
+        except Exception as exc:
+            print(f"[SynVowTransparentSave] URL RGBA 下载失败 ({attempt + 1}/3): {short} {exc}")
+    return None
+
+
+def _download_rgba_images(urls: List[str]) -> List[Optional[Image.Image]]:
+    result = []
+    for url in urls:
+        result.append(_download_rgba_from_url(url))
+    return result
+
+
+def _rgba_pil_to_tensor(image: Image.Image) -> torch.Tensor:
+    array = np.asarray(image.convert("RGB")).astype(np.float32) / 255.0
+    return torch.from_numpy(array).unsqueeze(0)
+
+
+def _has_real_alpha(image: Image.Image) -> bool:
+    alpha = image.convert("RGBA").getchannel("A")
+    return bool(min(alpha.getdata()) < 255)
+
+
+def _border_connected_mask(candidate: np.ndarray) -> np.ndarray:
+    height, width = candidate.shape
+    connected = np.zeros((height, width), dtype=bool)
+    queue = deque()
+
+    def add(y, x):
+        if candidate[y, x] and not connected[y, x]:
+            connected[y, x] = True
+            queue.append((y, x))
+
+    for x in range(width):
+        add(0, x)
+        add(height - 1, x)
+    for y in range(height):
+        add(y, 0)
+        add(y, width - 1)
+
+    while queue:
+        y, x = queue.popleft()
+        if y > 0:
+            add(y - 1, x)
+        if y + 1 < height:
+            add(y + 1, x)
+        if x > 0:
+            add(y, x - 1)
+        if x + 1 < width:
+            add(y, x + 1)
+    return connected
+
+
+def _repair_fake_checkerboard_alpha(image: Image.Image) -> tuple:
+    rgba = image.convert("RGBA")
+    if _has_real_alpha(rgba):
+        return rgba, ""
+
+    array = np.asarray(rgba).copy()
+    rgb = array[:, :, :3].astype(np.int16)
+    channel_max = rgb.max(axis=2)
+    channel_min = rgb.min(axis=2)
+    gray = rgb.mean(axis=2)
+
+    light_neutral = (channel_max - channel_min <= 24) & (gray >= 175)
+    connected = _border_connected_mask(light_neutral)
+    bg_ratio = float(connected.mean())
+    if bg_ratio < 0.08:
+        return rgba, ""
+
+    bg_gray = gray[connected]
+    if bg_gray.size < 256:
+        return rgba, ""
+
+    spread = float(np.percentile(bg_gray, 95) - np.percentile(bg_gray, 5))
+    light_ratio = float(np.mean(bg_gray >= 238))
+    mid_ratio = float(np.mean((bg_gray >= 185) & (bg_gray <= 232)))
+    if spread < 12 or light_ratio < 0.08 or mid_ratio < 0.08:
+        return rgba, ""
+
+    array[connected, :3] = 0
+    array[connected, 3] = 0
+    repaired = Image.fromarray(array, "RGBA")
+    return repaired, f"checkerboard_to_alpha:{bg_ratio:.0%}"
+
+
+class SynVowTransparentPngSavePreview:
+    def __init__(self):
+        self.output_dir = folder_paths.get_output_directory()
+        self.type = "output"
+        self.compress_level = 4
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image_urls": ("STRING", {"forceInput": True}),
+                "save_path": ("STRING", {"default": "SynVowTransparent"}),
+                "filename_prefix": ("STRING", {"default": "transparent"}),
+            },
+            "hidden": {
+                "prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE", "STRING", "STRING")
+    RETURN_NAMES = ("saved_images", "rgba_file_paths", "status")
+    FUNCTION = "save"
+    INPUT_IS_LIST = True
+    OUTPUT_IS_LIST = (True, False, False)
+    OUTPUT_NODE = True
+    CATEGORY = CATEGORY
+    DESCRIPTION = "从 image_urls 下载原始 RGBA PNG，并保存真实 Alpha 通道透明图。"
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return random.random()
+
+    def save(
+        self,
+        image_urls,
+        save_path="SynVowTransparent",
+        filename_prefix="transparent",
+        prompt=None,
+        extra_pnginfo=None,
+    ):
+        raw_save_path = _raw_path(save_path, default="SynVowTransparent")
+        is_absolute_save = _is_absolute_save_path(raw_save_path)
+        filename_prefix = _safe_filename_prefix(filename_prefix, default="transparent")
+        prompt = _unpack(prompt)
+        extra_pnginfo = _unpack(extra_pnginfo)
+
+        url_list = _collect_urls(image_urls)
+        url_rgba_list = _download_rgba_images(url_list) if url_list else []
+        valid_url_rgba = [img for img in url_rgba_list if img is not None]
+
+        if not valid_url_rgba:
+            raise ValueError("没有收到可下载的 image_urls，或 URL 下载失败。")
+
+        width, height = valid_url_rgba[0].size
+
+        if is_absolute_save:
+            full_output_folder = os.path.abspath(raw_save_path)
+            os.makedirs(full_output_folder, exist_ok=True)
+            filename = filename_prefix
+            counter = _next_counter(full_output_folder, filename)
+            subfolder = ""
+            preview_folder, preview_filename, preview_counter, preview_subfolder, _ = folder_paths.get_save_image_path(
+                f"SynVowTransparentPreview/{filename_prefix}",
+                self.output_dir,
+                width,
+                height,
+            )
+        else:
+            relative_save_path = _safe_relative_path(raw_save_path, default="SynVowTransparent")
+            output_prefix = f"{relative_save_path}/{filename_prefix}" if relative_save_path else filename_prefix
+            full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(
+                output_prefix,
+                self.output_dir,
+                width,
+                height,
+            )
+            preview_folder = None
+            preview_filename = None
+            preview_counter = None
+            preview_subfolder = None
+
+        metadata = None
+        if not args.disable_metadata:
+            metadata = PngInfo()
+            if prompt is not None:
+                metadata.add_text("prompt", json.dumps(prompt))
+            if isinstance(extra_pnginfo, dict):
+                for key in extra_pnginfo:
+                    metadata.add_text(key, json.dumps(extra_pnginfo[key]))
+
+        ui_results = []
+        saved_tensors = []
+        rgba_paths = []
+        alpha_count = 0
+        checkerboard_repaired_count = 0
+        url_saved_count = 0
+
+        for batch_number in range(len(url_rgba_list)):
+            rgba = url_rgba_list[batch_number] if batch_number < len(url_rgba_list) else None
+            if rgba is None:
+                continue
+            rgba = rgba.convert("RGBA")
+            repair_info = ""
+            if not _has_real_alpha(rgba):
+                rgba, repair_info = _repair_fake_checkerboard_alpha(rgba)
+                if repair_info:
+                    checkerboard_repaired_count += 1
+                    print(f"[SynVowTransparentSave] 棋盘格假透明已转 Alpha ({batch_number + 1}): {repair_info}")
+            has_alpha = _has_real_alpha(rgba)
+            url_saved_count += 1
+            if has_alpha:
+                alpha_count += 1
+
+            filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
+            rgba_path, rgba_file, counter = _next_available_png_path(full_output_folder, filename_with_batch_num, counter)
+            rgba.save(rgba_path, pnginfo=metadata, compress_level=self.compress_level)
+            rgba_paths.append(rgba_path)
+            saved_tensors.append(_rgba_pil_to_tensor(rgba))
+
+            if is_absolute_save:
+                preview_name = preview_filename.replace("%batch_num%", str(batch_number))
+                ui_filename = f"{preview_name}_{preview_counter:05}_alpha.png"
+                preview_path = os.path.join(preview_folder, ui_filename)
+                rgba.save(preview_path, pnginfo=metadata, compress_level=self.compress_level)
+                ui_subfolder = preview_subfolder
+                preview_counter += 1
+            else:
+                ui_filename = rgba_file
+                ui_subfolder = subfolder
+
+            ui_results.append({
+                "filename": ui_filename,
+                "subfolder": ui_subfolder,
+                "type": self.type,
+            })
+            counter += 1
+
+        display_folder = full_output_folder if is_absolute_save else (subfolder or ".")
+        status = (
+            f"已保存 {len(rgba_paths)} 张 RGBA PNG；检测到透明像素 {alpha_count}/{len(rgba_paths)}；"
+            f"棋盘格假透明修复 {checkerboard_repaired_count}/{len(rgba_paths)}；"
+            f"URL原图保存 {url_saved_count}/{len(rgba_paths)}；保存目录 {display_folder}。"
+        )
+        if is_absolute_save:
+            status += " 已在 ComfyUI output/SynVowTransparentPreview 生成同 alpha 预览副本。"
+        if alpha_count == 0:
+            status += " 注意：未检测到透明像素，请检查上游 URL 是否是带 alpha 的 PNG。"
+
+        return {
+            "ui": {"images": ui_results},
+            "result": (saved_tensors, "\n".join(rgba_paths), status),
+        }
+
+
+NODE_CLASS_MAPPINGS = {
+    "SynVowTransparentPngSavePreview": SynVowTransparentPngSavePreview,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "SynVowTransparentPngSavePreview": "SynVow 透明PNG保存预览",
+}

--- a/py/prompts/transparent_asset_generator_prompts.json
+++ b/py/prompts/transparent_asset_generator_prompts.json
@@ -1,0 +1,199 @@
+{
+  "scene_presets": [
+    "通用透明素材",
+    "参考图分层拆图",
+    "电商素材包",
+    "UI图标套装",
+    "人物/IP贴纸",
+    "周边贴纸素材",
+    "游戏道具素材",
+    "节日活动素材"
+  ],
+  "planner_modes": [
+    "自动规划(LLM)",
+    "规则预设(不调用LLM)"
+  ],
+  "asset_counts": [
+    "1",
+    "2",
+    "4",
+    "6",
+    "8",
+    "12"
+  ],
+  "style_strengths": [
+    "保守",
+    "标准",
+    "丰富",
+    "高表现"
+  ],
+  "complexities": [
+    "简洁",
+    "适中",
+    "丰富"
+  ],
+  "postprocess_modes": [
+    "裁边留白",
+    "仅检测Alpha"
+  ],
+  "defaults": {
+    "scene_preset": "电商素材包",
+    "planner_mode": "自动规划(LLM)",
+    "asset_count": "6",
+    "style_strength": "标准",
+    "complexity": "适中",
+    "postprocess_mode": "裁边留白"
+  },
+  "scene_hints": {
+    "通用透明素材": "Generate one user requested object as a clean transparent PNG asset.",
+    "参考图分层拆图": "Split the provided reference poster or product visual into practical design layers: text/logo, main subject/person/product, background, and decorative foreground elements. Do not invent new props or unrelated assets; only recreate layers that are visible in the reference image.",
+    "电商素材包": "Use a coherent ecommerce overlay component style across separate outputs: product decoration, selling-point tags, feature icons, arrows, labels, supporting props, particles, water drops, petals, food fragments, ribbons, geometry and commercial visual accents. Each output should contain one component only.",
+    "UI图标套装": "Use a coherent UI icon-set style for apps, websites, SaaS, mini programs or dashboards. Keep consistent perspective, material, stroke/volume, lighting and size across separate outputs. Upload/download icons must keep clear arrow direction and must not become icon sheets.",
+    "人物/IP贴纸": "Use a coherent simple original cartoon mascot/emote sticker style across separate outputs. Treat every output as the same sticker pack and the same original character: keep identical chibi proportions, face shape, eye rendering style, hair design, line thickness, sticker outline, material, lighting, camera angle and level of detail. Prefer non-real-person mascot heads, busts, rounded characters or simplified emotes. Preserve only the general character identity when a reference image is provided; each output should contain one pose, expression, gesture or sticker action only.",
+    "周边贴纸素材": "Use a coherent physical merchandise sticker artwork style across separate outputs for fridge magnets, journaling stickers, acrylic standees, packaging stickers and cultural creative products. Each output should contain one sticker artwork only.",
+    "游戏道具素材": "Use a coherent game-ready transparent asset style across separate outputs: item icons, skill icons, inventory objects, cards, badges, props, weapons, potions, coins, gems, magic effects and avatar decorations. Each output should contain one game asset only.",
+    "节日活动素材": "Use a coherent holiday and campaign transparent element style: festival decorations, promotion tags, celebration props, seasonal icons and event atmosphere assets. Generate each element as a separate output."
+  },
+  "fallback_items": {
+    "参考图分层拆图": [
+      "文字/Logo层",
+      "主体/人物/产品层",
+      "背景层",
+      "装饰元素层",
+      "光影氛围层",
+      "其他可复用元素层"
+    ],
+    "电商素材包": [
+      "产品主视觉装饰光环",
+      "卖点空白标签",
+      "功能小图标",
+      "细节指示箭头",
+      "漂浮粒子装饰",
+      "场景陪衬小道具",
+      "促销爆炸贴",
+      "材质/成分辅助元素",
+      "丝带/几何装饰",
+      "水滴/花瓣/食材碎片",
+      "品牌感留白标题底板",
+      "广告氛围高光元素"
+    ],
+    "UI图标套装": [
+      "首页图标",
+      "搜索图标",
+      "上传图标",
+      "下载图标",
+      "编辑图标",
+      "收藏图标",
+      "消息图标",
+      "设置图标",
+      "订单图标",
+      "支付图标",
+      "AI生成图标",
+      "数据分析图标"
+    ],
+    "人物/IP贴纸": [
+      "开心挥手贴纸",
+      "惊讶表情贴纸",
+      "点赞动作贴纸",
+      "疑问表情贴纸",
+      "加油鼓励贴纸",
+      "手持空白牌贴纸",
+      "指向箭头动作贴纸",
+      "比心动作贴纸",
+      "胜利手势贴纸",
+      "思考表情贴纸",
+      "庆祝动作贴纸",
+      "无语表情贴纸"
+    ],
+    "周边贴纸素材": [
+      "主形象贴纸",
+      "圆形徽章贴纸",
+      "冰箱贴主体图案",
+      "手账小装饰",
+      "包装封口贴",
+      "亚克力立牌图案",
+      "城市/地标贴纸",
+      "甜品/咖啡贴纸",
+      "可爱小物贴纸",
+      "节日小贴纸",
+      "边框装饰贴纸",
+      "空白文字贴纸底板"
+    ],
+    "游戏道具素材": [
+      "金币道具图标",
+      "宝箱道具图标",
+      "生命药水图标",
+      "魔法水晶图标",
+      "武器道具图标",
+      "护盾徽章图标",
+      "火焰技能图标",
+      "冰霜技能图标",
+      "闪电技能图标",
+      "稀有卡牌边框",
+      "头像挂件",
+      "任务奖励图标"
+    ],
+    "节日活动素材": [
+      "节日主装饰",
+      "活动促销标签",
+      "礼盒元素",
+      "彩带飘带",
+      "节日徽章",
+      "倒计时标签",
+      "优惠券底板",
+      "氛围粒子",
+      "节日小道具",
+      "空白标题牌",
+      "角标贴纸",
+      "庆祝烟花元素"
+    ]
+  },
+  "transparent_constraints": "Transparent PNG asset, true transparent background, real alpha channel, isolated subject, no scene background, no wall, no floor, no surface, no solid color backdrop, no checkerboard background, no transparency grid, no fake transparent pattern, no transparency preview canvas, clean cutout edge, centered composition, full object visible, safe margin, usable as a design overlay element. Do not draw or simulate transparency; leave the background empty through the alpha channel.",
+  "planner_system_prompt": "You are a ComfyUI transparent visual asset pack planner. Plan assets that will be generated one-by-one as separate transparent PNG overlay elements. Return strict JSON only, no markdown. Schema: {\"style_prompt\":\"English global visual style lock applied verbatim to every generated asset\",\"items\":[{\"name\":\"short Chinese name\",\"description\":\"usage description\",\"prompt\":\"English image generation prompt for exactly one transparent PNG asset\"}]}. The style_prompt must be one reusable global style paragraph that fixes the whole pack's art direction: character identity when relevant, proportions, perspective/camera angle, material, surface finish, stroke/outline, lighting, shadow softness, color palette, detail density, edge treatment and sticker/icon/asset presentation. Every item prompt must describe exactly one isolated asset for one image output only and must not contradict style_prompt. Never ask for an asset sheet, icon grid, sticker sheet, item grid, nine-grid, contact sheet, collage, multiple objects, full poster, full ecommerce main image, full UI screen, or full scene. If the scene is reference layer split, use only layout layers visible in the reference image: text/logo layer, main subject/person/product layer, background layer, decorative elements layer; do not invent new props, mascots, food, icons, or unrelated assets. For UI upload/download icons, keep one clear arrow direction only. For character/IP stickers, plan one consistent original non-real-person cartoon mascot/emote pack; keep the same character identity, chibi proportions, face shape, eye style, hair design, material, lighting, outline and camera angle across items, and only vary expression, gesture or a small prop; avoid realistic human likeness, celebrity likeness and complex full-body anatomy unless explicitly required by the user. Avoid visible text unless the asset is explicitly a text/logo layer, blank label or blank badge; for labels, generate blank text areas only.",
+  "planner_requirements": [
+    "Plan exactly asset_count items.",
+    "Each item must be reusable as a transparent PNG component.",
+    "The whole pack must share one consistent visual style.",
+    "Return one style_prompt that will be copied into every final generation prompt as the global visual style lock.",
+    "Prompts must request isolated objects with clean alpha-ready edges.",
+    "Each generated image should contain one object only.",
+    "Do not plan full posters, full ecommerce main images, full UI screens, icon sheets, sticker sheets, item grids, contact sheets, collages, or multi-object layouts."
+  ],
+  "style_strength_map": {
+    "保守": "practical, clean, restrained, easy to reuse",
+    "标准": "balanced commercial quality, reusable and polished",
+    "丰富": "richer detail, stronger decoration, still clean and reusable",
+    "高表现": "high-impact, eye-catching, premium visual expression"
+  },
+  "complexity_map": {
+    "简洁": "simple silhouette, minimal detail, high readability",
+    "适中": "moderate detail, clear subject, commercial polish",
+    "丰富": "rich detail, layered material, strong visual presence"
+  },
+  "scene_generation_rules": {
+    "通用透明素材": "One transparent reusable asset only. Exactly one object in this output, no asset sheet, no grid, no collage, no multiple objects.",
+    "参考图分层拆图": "Reference layer split mode. Output exactly the requested layer from the provided reference image. Do not invent objects that are not visible in the reference. Text/logo layer may contain visible text; background layer may be a full-frame background plate; foreground layers should use real alpha outside the layer content.",
+    "电商素材包": "One commercial ecommerce overlay component only. No full product poster, no complete main image layout, no asset sheet, no collage, no extra props, no visible marketing copy unless it is a blank label shape.",
+    "UI图标套装": "Single UI icon asset only. Exactly one symbol per output, not an icon sheet, not an icon grid, not a nine-grid, not an icon group, not multiple mini icons, consistent icon-set style, centered, clear silhouette, no text, no app screen, no full interface. Upload must use an upward arrow; download must use a downward arrow into tray/inbox.",
+    "人物/IP贴纸": "One simple original cartoon mascot/emote sticker asset only with clean contour and one expressive pose. It must belong to the same sticker pack and same original character as the other outputs: identical chibi proportions, face shape, eye rendering, hair design, material, lighting, outline/border, camera angle and detail level; only expression, gesture or a small prop may change. Prefer head, bust, rounded character or simplified emote composition. No realistic human likeness, no celebrity likeness, no complex full-body anatomy, no detailed hands, no multiple characters, no sticker sheet, no contact sheet, no multiple poses in one image, no background scene, no text unless user requested a blank sign.",
+    "周边贴纸素材": "One merchandise sticker artwork only. Printable clean edge, appealing contour, no sticker sheet, no contact sheet, no product mockup background, suitable for fridge magnets, journaling stickers or acrylic products.",
+    "游戏道具素材": "One game asset icon or prop only, readable at small size, strong silhouette. No inventory grid, no item sheet, no item collection, no UI panel unless requested, no full game scene.",
+    "节日活动素材": "One holiday or campaign decoration asset only, festive but reusable. No element sheet, no contact sheet, no complete poster, no layout, blank labels if label shapes are needed."
+  },
+  "generation_prompt_template": [
+    "Single transparent asset request: {item_prompt}",
+    "Asset name: {item_name}",
+    "{style_lock}",
+    "{scene_rule}",
+    "{transparent_constraints}",
+    "Output only the isolated subject on real alpha transparency. Do not visualize transparency as a checkerboard, gray-white grid, preview canvas, white square, background, frame, canvas texture, floor shadow, watermark, signature, extra objects, asset sheet, icon grid, nine-grid, sticker sheet, item grid, contact sheet, collage, or multi-object layout."
+  ],
+  "layout_split_generation_prompt_template": [
+    "Reference image layer split request: {item_prompt}",
+    "Layer name: {item_name}",
+    "{style_lock}",
+    "{scene_rule}",
+    "{transparent_constraints}",
+    "Output only this one design layer. Do not invent new visual assets. Do not output a contact sheet, asset pack, grid, collage, full poster, or unrelated object. For text/logo layer, visible text and logo shapes are allowed. For background layer, a full-frame background plate is allowed. For other layers, keep real alpha outside the extracted/recreated content. Never render a checkerboard, gray-white grid, transparency preview canvas, or fake transparency pattern."
+  ]
+}

--- a/web/gpt_image_2_alpha.js
+++ b/web/gpt_image_2_alpha.js
@@ -1,0 +1,122 @@
+import { app } from "../../scripts/app.js";
+
+const TARGET_NODE = "SynVowGptImage2Alpha_TBatch";
+const STALE_OUTPUTS = new Set(["images", "masks"]);
+const CANONICAL_OUTPUTS = ["image_urls", "status"];
+const CANCEL_WIDGET_NAME = "取消轮询";
+
+function moveOutputLinks(node, fromIndex, toIndex) {
+    const fromOutput = node.outputs?.[fromIndex];
+    const toOutput = node.outputs?.[toIndex];
+    if (!fromOutput || !toOutput || fromIndex === toIndex) return;
+
+    const links = Array.isArray(fromOutput.links) ? [...fromOutput.links] : [];
+    if (!links.length) return;
+    if (!Array.isArray(toOutput.links)) toOutput.links = [];
+
+    for (const linkId of links) {
+        const link = app.graph?.links?.[linkId];
+        if (link) {
+            link.origin_slot = toIndex;
+        }
+        if (!toOutput.links.includes(linkId)) {
+            toOutput.links.push(linkId);
+        }
+    }
+    fromOutput.links = [];
+}
+
+function removeDuplicateOutput(node, name) {
+    let indexes = node.outputs
+        .map((output, index) => ({ output, index }))
+        .filter(({ output }) => output?.name === name)
+        .map(({ index }) => index);
+
+    while (indexes.length > 1) {
+        const keepIndex = indexes[0];
+        const removeIndex = indexes[indexes.length - 1];
+        moveOutputLinks(node, removeIndex, keepIndex);
+        node.removeOutput(removeIndex);
+        indexes = node.outputs
+            .map((output, index) => ({ output, index }))
+            .filter(({ output }) => output?.name === name)
+            .map(({ index }) => index);
+    }
+}
+
+function cleanAlphaNodeOutputs(node) {
+    if (!node || !Array.isArray(node.outputs)) return;
+
+    for (let index = node.outputs.length - 1; index >= 0; index--) {
+        const output = node.outputs[index];
+        if (output && STALE_OUTPUTS.has(output.name)) {
+            node.removeOutput(index);
+        }
+    }
+
+    for (const name of CANONICAL_OUTPUTS) {
+        removeDuplicateOutput(node, name);
+    }
+
+    node.setSize?.(node.computeSize?.() || node.size);
+    app.graph?.setDirtyCanvas(true, true);
+}
+
+function addAlphaCancelWidget(node) {
+    if (!node || node.widgets?.find((widget) => widget.name === CANCEL_WIDGET_NAME)) return;
+
+    const button = node.addWidget("button", CANCEL_WIDGET_NAME, null, () => {
+        button.value = "已发送中断信号";
+        fetch("/synvow/alpha/cancel", { method: "POST" }).catch((error) => {
+            console.error("[SynVow] alpha cancel failed:", error);
+        });
+        fetch("/interrupt", { method: "POST" }).catch((error) => {
+            console.error("[SynVow] interrupt failed:", error);
+        });
+        setTimeout(() => {
+            button.value = CANCEL_WIDGET_NAME;
+        }, 3000);
+    });
+    button.serialize = false;
+}
+
+function refreshAlphaNode(node) {
+    cleanAlphaNodeOutputs(node);
+    addAlphaCancelWidget(node);
+}
+
+app.registerExtension({
+    name: "SynVow.GptImage2AlphaUrlOnly",
+
+    async beforeRegisterNodeDef(nodeType, nodeData) {
+        if (nodeData.name !== TARGET_NODE) return;
+
+        const onNodeCreated = nodeType.prototype.onNodeCreated;
+        nodeType.prototype.onNodeCreated = function () {
+            const result = onNodeCreated?.apply(this, arguments);
+            setTimeout(() => refreshAlphaNode(this), 0);
+            return result;
+        };
+
+        const onConfigure = nodeType.prototype.onConfigure;
+        nodeType.prototype.onConfigure = function () {
+            const result = onConfigure?.apply(this, arguments);
+            setTimeout(() => refreshAlphaNode(this), 0);
+            return result;
+        };
+    },
+
+    async setup() {
+        setTimeout(() => {
+            for (const node of app.graph?._nodes || []) {
+                if (node.type === TARGET_NODE) refreshAlphaNode(node);
+            }
+        }, 500);
+    },
+
+    afterConfigureGraph() {
+        for (const node of app.graph?._nodes || []) {
+            if (node.type === TARGET_NODE) refreshAlphaNode(node);
+        }
+    },
+});

--- a/web/transparent_png_save_preview.js
+++ b/web/transparent_png_save_preview.js
@@ -1,0 +1,53 @@
+import { app } from "../../scripts/app.js";
+
+const TARGET_NODE = "SynVowTransparentPngSavePreview";
+const STALE_INPUTS = new Set(["images", "masks"]);
+const STALE_WIDGETS = new Set(["preview_background", "save_preview_copy", "mask_mode"]);
+
+function cleanTransparentSaveNode(node) {
+    if (!node) return;
+
+    if (Array.isArray(node.inputs)) {
+        for (let index = node.inputs.length - 1; index >= 0; index--) {
+            const input = node.inputs[index];
+            if (input && STALE_INPUTS.has(input.name)) {
+                node.removeInput(index);
+            }
+        }
+    }
+
+    if (Array.isArray(node.widgets)) {
+        for (let index = node.widgets.length - 1; index >= 0; index--) {
+            const widget = node.widgets[index];
+            if (widget && STALE_WIDGETS.has(widget.name)) {
+                widget.onRemove?.();
+                node.widgets.splice(index, 1);
+            }
+        }
+    }
+
+    node.setSize?.(node.computeSize?.() || node.size);
+    app.graph?.setDirtyCanvas(true, true);
+}
+
+app.registerExtension({
+    name: "SynVow.TransparentPngSavePreview",
+
+    async beforeRegisterNodeDef(nodeType, nodeData) {
+        if (nodeData.name !== TARGET_NODE) return;
+
+        const onNodeCreated = nodeType.prototype.onNodeCreated;
+        nodeType.prototype.onNodeCreated = function () {
+            const result = onNodeCreated?.apply(this, arguments);
+            setTimeout(() => cleanTransparentSaveNode(this), 0);
+            return result;
+        };
+
+        const onConfigure = nodeType.prototype.onConfigure;
+        nodeType.prototype.onConfigure = function () {
+            const result = onConfigure?.apply(this, arguments);
+            setTimeout(() => cleanTransparentSaveNode(this), 0);
+            return result;
+        };
+    },
+});


### PR DESCRIPTION
## Summary

Add the transparent asset generation workflow nodes to the SynVow ComfyUI plugin.

## Changes

- Add `SynVow GPT-Image-2 Alpha (T_batch)` for transparent PNG URL generation.
- Add `SynVow 透明素材提示词生成器`.
- Add `SynVow 透明PNG保存预览`.
- Add transparent asset prompt config JSON.
- Add frontend helpers for Alpha cancel polling and legacy input/output cleanup.

## Notes

- This PR only includes the 6 core node/frontend/prompt files.
- Workflow template files are intentionally not included in this PR.
- No API keys or local absolute paths are included.

## Validation

- Python compile check passed.
- Prompt JSON parse check passed.
- Cached diff check passed.